### PR TITLE
[증명서] 증명서 폼 누락 내용 수정 및 퇴직시 재직 증명서 발급 못 하도록 수정 

### DIFF
--- a/vms/src/main/resources/templates/certificate/careercertificate.html
+++ b/vms/src/main/resources/templates/certificate/careercertificate.html
@@ -102,6 +102,7 @@
                     <td>경력사항</td>
                     <td>
 						<p th:if="${certificate.hireDate != null}" th:text="${#dates.format(certificate.hireDate, 'yyyy년 MM월 dd일')} + ' 부터 ' + ${certificate.deptName} + ' 부서 근무'"></p>
+                        <p th:if="${certificate.retireDate == null}" th:text="' ~ ' + ${#dates.format(certificate.regDate, 'yyyy년 MM월 dd일')} + ' 재직중'"></p>
                         <p th:if="${certificate.retireDate != null}" th:text="${#dates.format(certificate.hireDate, 'yyyy년 MM월 dd일')} + ' 사직'"></p>
                     </td>
                 </tr>

--- a/vms/src/main/resources/templates/certificate/careercertificatePreView.html
+++ b/vms/src/main/resources/templates/certificate/careercertificatePreView.html
@@ -102,6 +102,7 @@
                     <td>경력사항</td>
                     <td>
 						<p th:if="${employee.hireDate != null}" th:text="${#temporals.format(employee.hireDate, 'yyyy년 MM월 dd일')} + ' 부터 ' + ${deptName} + ' 부서 근무'"></p>
+                        <p th:if="${employee.retireDate == null}" th:text="' ~ ' + ${#dates.format(today, 'yyyy년 MM월 dd일')} + ' 재직중'"></p>
                         <p th:if="${employee.retireDate != null}" th:text="${#temporals.format(employee.retireDate, 'yyyy년 MM월 dd일')} + ' 사직'"></p>
                     </td>
                 </tr>

--- a/vms/src/main/resources/templates/certificate/request.html
+++ b/vms/src/main/resources/templates/certificate/request.html
@@ -63,8 +63,10 @@
 		        <tr>
 		            <td>재직증명서</td>
 		            <td>재직을 증명하는 문서입니다.</td>
-		            <td><button onclick="certificatePreViewOpen('재직증명서')" class="btn btn-primary">미리보기</button></td>
-		            <td><button onclick="requestCertificate('재직증명서')" class="btn btn-success">신청</button></td>
+		            <td><button th:if="${employee.retireDate == null}" onclick="certificatePreViewOpen('재직증명서')" 
+		            		class="btn btn-primary">미리보기</button></td>
+		            <td><button th:if="${employee.retireDate == null}" onclick="requestCertificate('재직증명서')" 
+		            		class="btn btn-success">신청</button></td>
 		        </tr>
 		        <tr>
 		            <td>퇴직증명서</td>

--- a/vms/src/main/resources/templates/certificate/request.html
+++ b/vms/src/main/resources/templates/certificate/request.html
@@ -7,8 +7,12 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
 </head>
 <style>
+	#certificateRequestBody {
+		padding: 20px;
+	}
 	table {
 	  border: 1px #a39485 solid;
 	  font-size: .9em;
@@ -40,158 +44,41 @@
 	}
 </style>
 <body>
+	<div id="certificateRequestBody">
+		<h2>증명서 발급</h2>
+	    <table>
+	        <thead>
+	            <th>양식명</th>
+	            <th>양식설명</th>
+	            <th colspan="1"></th>
+	            <th colspan="1"></th>
+	        </thead>
+	        <tbody>
+		        <tr>
+		            <td>경력증명서</td>
+		            <td>경력을 증명는 문서입니다.</td>
+		            <td><button onclick="certificatePreViewOpen('경력증명서')" class="btn btn-primary">미리보기</button></td>
+		            <td><button onclick="requestCertificate('경력증명서')" class="btn btn-success">신청</button></td>
+		        </tr>
+		        <tr>
+		            <td>재직증명서</td>
+		            <td>재직을 증명하는 문서입니다.</td>
+		            <td><button onclick="certificatePreViewOpen('재직증명서')" class="btn btn-primary">미리보기</button></td>
+		            <td><button onclick="requestCertificate('재직증명서')" class="btn btn-success">신청</button></td>
+		        </tr>
+		        <tr>
+		            <td>퇴직증명서</td>
+		            <td>퇴사를 증명하는 문서입니다.</td>
+		            <td><button th:if="${employee.retireDate != null}" onclick="certificatePreViewOpen('퇴직증명서')"
+		                    class="btn btn-primary">미리보기</button></td>
+		            <td><button th:if="${employee.retireDate != null}" onclick="requestCertificate('퇴직증명서')"
+		                    class="btn btn-success">신청</button></td>
+		        </tr>
+			</tbody>
 	
-	 <h2>증명서 발급</h2>
-    <table>
-        <thead>
-            <th>양식명</th>
-            <th>양식설명</th>
-            <th></th>
-        </thead>
-        <tr>
-            <td>퇴직증명서</td>
-            <td><button th:if="${employee.retireDate != null}" onclick="certificatePreViewOpen('퇴직증명서')">미리보기</button></td>
-            <td><button th:if="${employee.retireDate != null}" onclick="requestCertificate('퇴직증명서')">신청</button></td>
-        </tr>
-        <tr>
-            <td>경력증명서</td>
-            <td><button onclick="certificatePreViewOpen('경력증명서')">미리보기</button></td>
-            <td><button onclick="requestCertificate('경력증명서')">신청</button></td>
-        </tr>
-        <tr>
-            <td>재직증명서</td>
-            <td><button onclick="certificatePreViewOpen('재직증명서')">미리보기</button></td>
-            <td><button onclick="requestCertificate('재직증명서')">신청</button></td>
-        </tr>
-    </table>
+	    </table>	
+	</div>
 
-    <!-- 퇴직증명서 -->
-    <div id="retirementcertificate" class="modal">
-        <div class="container">
-            <div class="header">
-                <h1>퇴직 증명서</h1>
-            </div>
-            <div class="certificateid">
-                <p>제 1111호</p>
-            </div>
-            <div class="content">
-                <table>
-                    <tr>
-                        <td id="item">성명</td>
-                        <td colspan="3">홍길동</td>
-                    </tr>
-                    <tr>
-                        <td id="item">직책</td>
-                        <td colspan="3">팀원</td>
-                    </tr>
-                    <tr>
-                        <td id="item">부서</td>
-                        <td colspan="3">개발</td>
-                    </tr>
-                    <tr>
-                        <td>회사명</td>
-                        <td colspan="3">Metanet</td>
-                    </tr>
-                    <tr>
-                        <td>입사일</td>
-                        <td>2023-11-01</td>
-                        <td>퇴사일</td>
-                        <td>2023-12-23</td>
-                    </tr>
-                </table>
-            </div>
-            <div class="context">
-                <p>상기와 같이 퇴직함을 증명합니다.</p>
-            </div>
-            <div class="signature">
-                <p>2023년 12월 29일</p>
-            </div>
-            <div class="blank"></div>
-        </div>
-    </div>
-    <!-- 경력증명서 -->
-    <div id="careercertificate" class="modal">
-        <div class="container">
-            <div class="header">
-                <h1>경력증명서</h1>
-            </div>
-            <div class="certificateid">
-                <p>제 1111호</p>
-            </div>
-            <div class="content">
-                <table>
-                    <tr>
-                        <td id="item">성명</td>
-                        <td>홍길동</td>
-                    </tr>
-                    <tr>
-                        <td id="item">직책</td>
-                        <td>팀원</td>
-                    </tr>
-                    <tr>
-                        <td>회사명</td>
-                        <td>Metanet</td>
-                    </tr>
-                    <tr>
-                        <td>경력사항</td>
-                        <td>
-                            <p>2022년 7월 1일부터 개발부 근무(1년 04개월)</p>
-                            <p>2023년 11월 1일 사직</p>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <div class="context">
-                <p>위 사람은 상기와 같이 근무하였음을 증명합니다.</p>
-            </div>
-            <div class="signature">
-                <p>2023년 12월 29일</p>
-            </div>
-            <div class="blank"></div>
-        </div>
-    </div>
-    <!-- 재직증명서 -->
-    <div id="employmentcertificate" class="modal">
-        <div class="container">
-            <div class="header">
-                <h1>재직증명서</h1>
-            </div>
-            <div class="certificateid">
-                <p>제 1111호</p>
-            </div>
-            <div class="content">
-                <table>
-                    <tr>
-                        <td id="item">성명</td>
-                        <td>홍길동</td>
-                    </tr>
-                    <tr>
-                        <td id="item">직책</td>
-                        <td>팀원</td>
-                    </tr>
-                    <tr>
-                        <td id="item">부서</td>
-                        <td>개발</td>
-                    </tr>
-                    <tr>
-                        <td>회사명</td>
-                        <td>Metanet</td>
-                    </tr>
-                    <tr>
-                        <td>입사일</td>
-                        <td>2023-11-01</td>
-                    </tr>
-                </table>
-            </div>
-            <div class="context">
-                <p>상기와 같이 재직함을 증명함</p>
-            </div>
-            <div class="signature">
-                <p>2023년 12월 29일</p>
-            </div>
-            <div class="blank"></div>
-        </div>
-    </div>
     
     <script th:inline="javascript">
 	    /*<![CDATA[*/

--- a/vms/src/main/resources/templates/certificate/view.html
+++ b/vms/src/main/resources/templates/certificate/view.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css" integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N" crossorigin="anonymous">
     <title>증명서 조회</title>
 </head>
 <style>
@@ -33,33 +34,38 @@
 	  border-bottom: 1px solid rgba(0,0,0,.1);
 	  background: #fff;
 	}
+	
+	#certificateViewBody {
+		padding: 20px;
+	}
 </style>
 <body>
+	<div id="certificateViewBody">
+	    <h2>발급한 증명서 조회</h2>
+	    <table>
+	        <thead>
+	            <tr>
+	                <th>문서명</th>
+	                <th>접수 번호</th>
+	                <th colspan="3">발급 날짜</th>
+	                <!-- Add more headers as needed -->
+	            </tr>
+	        </thead>
+	        <tbody>
+	            <tr th:each="certificate : ${certificates}">
+	                <td th:text="${certificate.type}"></td>
+	                <td th:text="${certificate.certificateId}"></td>
+	                <td th:text="${#dates.format(certificate.regDate, 'yyyy년 MM월 dd일')}"></td>
+	                <td>
+	                    <button th:if="${certificate.type eq '재직증명서'}" class="btn btn-primary" onclick="certificateDownload('재직증명서')">발급받기</button>
+	                    <button th:if="${certificate.type eq '경력증명서'}" class="btn btn-primary" onclick="certificateDownload('경력증명서')">발급받기</button>
+	                    <button th:if="${certificate.type eq '퇴직증명서'}" class="btn btn-primary" onclick="certificateDownload('퇴직증명서')">발급받기</button>
+	                </td>
+	            </tr>
+	        </tbody>
+	    </table>
+	</div>
 
-    <h2>발급한 증명서 조회</h2>
-
-    <table>
-        <thead>
-            <tr>
-                <th>문서명</th>
-                <th>접수 번호</th>
-                <th colspan="3">발급 날짜</th>
-                <!-- Add more headers as needed -->
-            </tr>
-        </thead>
-        <tbody>
-            <tr th:each="certificate : ${certificates}">
-                <td th:text="${certificate.type}"></td>
-                <td th:text="${certificate.certificateId}"></td>
-                <td th:text="${#dates.format(certificate.regDate, 'yyyy년 MM월 dd일')}"></td>
-                <td>
-                    <button th:if="${certificate.type eq '재직증명서'}" onclick="certificateDownload('재직증명서')">발급받기</button>
-                    <button th:if="${certificate.type eq '경력증명서'}" onclick="certificateDownload('경력증명서')">발급받기</button>
-                    <button th:if="${certificate.type eq '퇴직증명서'}" onclick="certificateDownload('퇴직증명서')">발급받기</button>
-                </td>
-            </tr>
-        </tbody>
-    </table>
 
 	<script th:inline="javascript">
 	    /*<![CDATA[*/


### PR DESCRIPTION
## 개요

- 경력 증명서에서 발급한 날짜까지 재직 중임을 보이게 했습니다. 
- 증명서 뷰의 버튼에 부트스트랩을 적용했습니다.
- 퇴직자는 재직 증명서를 발급하지 못 하도록 버튼을 막았습니다. 

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).